### PR TITLE
Issue#33 music shall start automatically

### DIFF
--- a/classes/audioManager.class.js
+++ b/classes/audioManager.class.js
@@ -28,28 +28,16 @@ class AudioManager {
         this.isMuted = this._loadMuted();
         this.audios  = new Map();
 
-    Object.entries(definitions).forEach(([name, cfg]) => {
-        const audio = new Audio(cfg.src);
-        audio.loop = !!cfg.loop;
-        audio.volume = typeof cfg.volume === 'number' ? cfg.volume : 1.0;
-        audio.preload = 'auto';
-        this.audios.set(name, audio);
-    });
+        Object.entries(definitions).forEach(([name, cfg]) => {
+            const audio = new Audio(cfg.src);
+            audio.loop = !!cfg.loop;
+            audio.volume = typeof cfg.volume === 'number' ? cfg.volume : 1.0;
+            audio.preload = 'auto';
+            this.audios.set(name, audio);
+        });
 
-    this._applyMute();
-    this._autoplayForCurrentMode();
-
-    // // BGM after first User-Interaction 
-    
-    //     if (this.audios.has('bgmMenu')) {
-    //     const startMenuIfNeeded = () => {
-    //         if (this.mode !== 'menu') return;
-    //         this.play('bgmMenu');
-    //     };
-    //     document.addEventListener('click',   startMenuIfNeeded, { once: true });
-    //     document.addEventListener('keydown', startMenuIfNeeded, { once: true });
-    //     }
-
+        this._applyMute();
+        this._autoplayForCurrentMode();
 
         // DOM-Wiring, if DOM is ready
         this._initDomWhenReady();
@@ -198,8 +186,16 @@ class AudioManager {
      *
      * @param {'menu'|'game'} mode
      */
-    setMode(mode) {
-        this.mode = mode === 'game' ? 'game' : 'menu';
+    setMode(mode) { 
+        const newMode = mode === 'game' ? 'game' : 'menu'; 
+        if (this.mode === newMode) return; 
+        this.mode = newMode;
+        if (newMode === 'game') { 
+            this.stopMenuBgm(); 
+        } else { 
+            this.stopGameBgm(); 
+        }
+        this._autoplayForCurrentMode(); 
     }
 
     /** Plays menu background music. */

--- a/classes/audioManager.class.js
+++ b/classes/audioManager.class.js
@@ -87,12 +87,27 @@ class AudioManager {
         });
     }
 
+    /**
+     * Attempts to autoplay the appropriate background track for the current mode.
+     * Picks 'bgmGame' when in 'game' mode, otherwise 'bgmMenu'. If the selected
+     * track is not defined, no action is taken.
+     * @private
+     * @returns {void}
+     */
     _autoplayForCurrentMode() {
         const track = this.mode === 'game' ? 'bgmGame' : 'bgmMenu';
         if (!this.audios.has(track)) return; 
         this._playAutoplaySafe(track); 
     }
 
+    /**
+     * Tries to start playback of the given track immediately. If the browser blocks
+     * autoplay (common when audio is not muted), a one-time fallback is registered
+     * to start playback on the first user interaction (click or keydown).
+     * @private
+     * @param {string} name - The key of the audio track in this.audios 
+     * @returns {void}
+     */
     _playAutoplaySafe(name) { 
         const audio = this.audios.get(name); 
         if (!audio) return;
@@ -107,6 +122,13 @@ class AudioManager {
         } 
     }
 
+    /**
+     * Registers a one-time fallback to start the specified track on first user interaction.
+     * The listeners (click/keydown) are automatically removed after the initial trigger.
+     * @private
+     * @param {string} name  - The key of the audio track to start on interaction.
+     * @returns {void}
+     */
     _setupAutoplayFallback(name) { 
         const handler = () => { 
             const a = this.audios.get(name); 
@@ -183,9 +205,15 @@ class AudioManager {
 
     /**
      * Sets current mode used to determine menu/game background music logic.
-     *
-     * @param {'menu'|'game'} mode
-     */
+     * Side effects:
+     *  - Updates the internal mode state.
+     *  - Attempts to start the new mode’s background music immediately.
+     *  - If the browser blocks autoplay (due to policies), a one-time
+     *    fallback will start playback on the first user interaction.  
+     * 
+     * @param {'menu'|'game'} mode - Target mode for background music behavior.
+     * @returns {void} 
+     */ 
     setMode(mode) { 
         const newMode = mode === 'game' ? 'game' : 'menu'; 
         if (this.mode === newMode) return; 

--- a/classes/audioManager.class.js
+++ b/classes/audioManager.class.js
@@ -37,7 +37,7 @@ class AudioManager {
     });
 
     this._applyMute();
-    
+    this._autoplayForCurrentMode();
 
     // // BGM after first User-Interaction 
     
@@ -97,6 +97,37 @@ class AudioManager {
             audio.currentTime = 0;
         }
         });
+    }
+
+    _autoplayForCurrentMode() {
+        const track = this.mode === 'game' ? 'bgmGame' : 'bgmMenu';
+        if (!this.audios.has(track)) return; 
+        this._playAutoplaySafe(track); 
+    }
+
+    _playAutoplaySafe(name) { 
+        const audio = this.audios.get(name); 
+        if (!audio) return;
+
+        try {
+            const p = audio.play(); 
+            if (p && typeof p.catch === 'function') {
+                p.catch(() => this._setupAutoplayFallback(name)); 
+            } 
+        } catch { 
+            this._setupAutoplayFallback(name); 
+        } 
+    }
+
+    _setupAutoplayFallback(name) { 
+        const handler = () => { 
+            const a = this.audios.get(name); 
+            if (a) a.play().catch(() => {}); 
+            document.removeEventListener('click', handler); 
+            document.removeEventListener('keydown', handler); 
+        }; 
+        document.addEventListener('click', handler, { once: true }); 
+        document.addEventListener('keydown', handler, { once: true }); 
     }
     
     /**

--- a/classes/audioManager.class.js
+++ b/classes/audioManager.class.js
@@ -37,18 +37,18 @@ class AudioManager {
     });
 
     this._applyMute();
-
-
-    // BGM after first User-Interaction 
     
-        if (this.audios.has('bgmMenu')) {
-        const startMenuIfNeeded = () => {
-            if (this.mode !== 'menu') return;
-            this.play('bgmMenu');
-        };
-        document.addEventListener('click',   startMenuIfNeeded, { once: true });
-        document.addEventListener('keydown', startMenuIfNeeded, { once: true });
-        }
+
+    // // BGM after first User-Interaction 
+    
+    //     if (this.audios.has('bgmMenu')) {
+    //     const startMenuIfNeeded = () => {
+    //         if (this.mode !== 'menu') return;
+    //         this.play('bgmMenu');
+    //     };
+    //     document.addEventListener('click',   startMenuIfNeeded, { once: true });
+    //     document.addEventListener('keydown', startMenuIfNeeded, { once: true });
+    //     }
 
 
         // DOM-Wiring, if DOM is ready


### PR DESCRIPTION
Close Issue #33 .
Note:
Browser blockieren Autoplay ohne User-Interaktion, wenn Audio nicht stumm ist. 
Muted-Autoplay ist i. d. R. erlaubt.

Lösung: Beim Laden sofort versuchen zu starten (abhängig vom Modus), den Mute-Zustand anwenden und bei Blockierung automatisch auf die erste User-Interaktion als Fallback zurückgreifen.

Zusätzlich: Beim Wechsel von menu -> game automatisch den passenden Track starten.