### PR TITLE
#62 mobile controls usability

### DIFF
--- a/index.html
+++ b/index.html
@@ -143,7 +143,7 @@
         </div>
       </section>
       <section class="in-game-controls hide-screen">
-        <button id="btnPause" class="navigation-buttons in-game-mute-btn" aria-label="Pause" title="Pause">⏸</button>
+        <button id="btnPauseDesktop" class="navigation-buttons in-game-mute-btn" aria-label="Pause" title="Pause">⏸</button>
         <button type="button" id="muteBtnInGame" class="navigation-buttons in-game-mute-btn" aria-pressed="false" title="Mute/Unmute (Key M)">
           <img id="muteIcon" src="./assets/icons/volume_off.svg" alt="mute">
           <span class="visually-hidden">Sound</span>
@@ -179,7 +179,7 @@
       </div>
 
       <div id="mobileGameControls" class="mobile-controls" oncontextmenu="return false" aria-label="Mobile Spiel Steuerung" aria-hidden="truea">
-        <button id="btnPause" class="control-btn" aria-label="Pause" title="Pause">⏸</button>
+        <button id="btnPauseMobile" class="control-btn" aria-label="Pause" title="Pause">⏸</button>
         <button type="button" id="mobileMuteBtn" class="control-btn" aria-pressed="false" title="Mute/Unmute (Key M)">
           <img id="muteIcon" src="./assets/icons/volume_off.svg" alt="mute">
           <span class="visually-hidden">Sound</span>

--- a/index.html
+++ b/index.html
@@ -176,18 +176,20 @@
           <img src="./assets/img/rotate_device.png" alt="Please rotate your device">
         </div>
       </div>
+
+      <div id="mobileGameControls" class="mobile-controls" oncontextmenu="return false" aria-label="Mobile Spiel Steuerung" aria-hidden="truea">
+        <button id="btnPause" class="control-btn" aria-label="Pause" title="Pause">⏸</button>
+        <button type="button" id="mobileMuteBtn" class="control-btn" aria-pressed="false" title="Mute/Unmute (Key M)">
+          <img id="muteIcon" src="./assets/icons/volume_off.svg" alt="mute">
+          <span class="visually-hidden">Sound</span>
+        </button>
+      </div>
       
       <div id="mobileControls" class="mobile-controls" oncontextmenu="return false" aria-label="Mobile Steuerung" aria-hidden="true">
         <button id="btnLeft"  class="control-btn" aria-label="Nach links" title="Links">⟵</button>
         <button id="btnRight" class="control-btn" aria-label="Nach rechts" title="Rechts">⟶</button>
         <button id="btnJump"  class="control-btn" aria-label="Springen" title="Springen">⤴︎</button>
         <button id="btnThrow" class="control-btn" aria-label="Werfen"  title="Werfen"><img src="./assets/img/6_salsa_bottle/salsa_bottle.png" alt="salsa_bottle" class="mobile-btn-bottle"></button>
-        <button id="btnPause" class="control-btn" aria-label="Pause" title="Pause">⏸</button>
-        <button type="button" id="mobileMuteBtn" class="control-btn" aria-pressed="false" title="Mute/Unmute (Key M)">
-          <img id="muteIcon" src="./assets/icons/volume_off.svg" alt="mute">
-          <span class="visually-hidden">Sound</span>
-        </button>
-
       </div>
 
     </main>

--- a/index.html
+++ b/index.html
@@ -143,6 +143,7 @@
         </div>
       </section>
       <section class="in-game-controls hide-screen">
+        <button id="btnPause" class="navigation-buttons in-game-mute-btn" aria-label="Pause" title="Pause">⏸</button>
         <button type="button" id="muteBtnInGame" class="navigation-buttons in-game-mute-btn" aria-pressed="false" title="Mute/Unmute (Key M)">
           <img id="muteIcon" src="./assets/icons/volume_off.svg" alt="mute">
           <span class="visually-hidden">Sound</span>

--- a/index.html
+++ b/index.html
@@ -186,9 +186,12 @@
         </button>
       </div>
       
-      <div id="mobileControls" class="mobile-controls" oncontextmenu="return false" aria-label="Mobile Steuerung" aria-hidden="true">
+      <div id="mobileControlsLeft" class="mobile-thumb-controls" aria-hidden="true">
         <button id="btnLeft"  class="control-btn" aria-label="Nach links" title="Links">⟵</button>
         <button id="btnRight" class="control-btn" aria-label="Nach rechts" title="Rechts">⟶</button>
+      </div>
+
+      <div id="mobileControlsRight" class="mobile-thumb-controls" aria-hidden="true">
         <button id="btnJump"  class="control-btn" aria-label="Springen" title="Springen">⤴︎</button>
         <button id="btnThrow" class="control-btn" aria-label="Werfen"  title="Werfen"><img src="./assets/img/6_salsa_bottle/salsa_bottle.png" alt="salsa_bottle" class="mobile-btn-bottle"></button>
       </div>

--- a/scripts/game.js
+++ b/scripts/game.js
@@ -105,6 +105,19 @@ function setupInGameUI() {
     hideAllScreens();
     showScreen('.canvas-screen');
     showScreen('.in-game-controls');
+    setupDesktopPauseButton();
+}
+
+/**
+ * Attaches the pause/resume handler to the desktop in-game pause button.
+ */
+function setupDesktopPauseButton() {
+    const btn = document.getElementById('btnPauseDesktop');
+    if (!btn) return;
+    btn.onclick = function(e) {
+        e.preventDefault();
+        window.gamePaused ? window.resumeGame() : window.pauseGame();
+    }
 }
 
 /**

--- a/scripts/mobile-ui.js
+++ b/scripts/mobile-ui.js
@@ -1,5 +1,6 @@
 (function () {
-    const mobileControls = document.getElementById('mobileControls');
+    const mobileControlsLeft = document.getElementById('mobileControlsLeft');
+    const mobileControlsRight = document.getElementById('mobileControlsRight');
     const mobileGameControls = document.getElementById('mobileGameControls');
     const rotateOverlay  = document.getElementById('rotateOverlay');
     const canvasScreen   = document.querySelector('.canvas-screen');
@@ -85,7 +86,8 @@
  * @param {Object} flags - UI state flags from computeUIFlags().
  */
 function setMobileControlsDisplay(flags) {
-    mobileControls.style.display = (flags.showMobile && !flags.hideMobile) ? 'flex' : 'none';
+    mobileControlsLeft.style.display = (flags.showMobile && !flags.hideMobile) ? 'flex' : 'none';
+    mobileControlsRight.style.display = (flags.showMobile && !flags.hideMobile) ? 'flex' : 'none';
     mobileGameControls.style.display = (flags.showMobile && !flags.hideMobile) ? 'flex' : 'none';
 }
 
@@ -106,7 +108,8 @@ function setMobileInGameControlsDisplay(flags) {
  * @param {Object} flags - UI state flags from computeUIFlags().
  */
 function setMobileControlsAria(flags) {
-    mobileControls.setAttribute('aria-hidden', String(!flags.showMobile));
+    mobileControlsLeft.setAttribute('aria-hidden', String(!flags.showMobile));
+    mobileControlsRight.setAttribute('aria-hidden', String(!flags.showMobile));
     mobileGameControls.setAttribute('aria-hidden', String(!flags.showMobile));
 }
 
@@ -153,7 +156,8 @@ function setMobileControlsAria(flags) {
  * @param {Event} e
  */
     ['contextmenu'].forEach(evt => {
-        mobileControls.addEventListener(evt, e => e.preventDefault(), { passive: false });
+        mobileControlsLeft.addEventListener(evt, e => e.preventDefault(), { passive: false });
+        mobileControlsRight.addEventListener(evt, e => e.preventDefault(), { passive: false });
     });
     
 /**

--- a/scripts/mobile-ui.js
+++ b/scripts/mobile-ui.js
@@ -164,7 +164,7 @@ function setMobileControlsAria(flags) {
  * Attaches pause button behavior to mobile pause UI.
  */
     function setupPauseButton() {
-        const pauseBtn = document.querySelector('#btnPause');
+        const pauseBtn = document.querySelector('#btnPauseMobile');
         if (!pauseBtn) return;
         pauseBtn.addEventListener('pointerdown', e => {
             e.preventDefault();

--- a/scripts/mobile-ui.js
+++ b/scripts/mobile-ui.js
@@ -75,18 +75,40 @@
  * @param {Object} flags - State flags from computeUIFlags().
  */
     function updateMobileVisibility(flags) {
-        mobileControls.style.display = flags.showMobile ? 'flex' : 'none';
-        mobileGameControls.style.display = flags.showMobile ? 'flex' : 'none';
-        if (flags.showMobile) {
-                inGameControls.classList.add('hide-screen');
-            } else {
-                inGameControls.classList.remove('show-screen');
-            }        
-        if (flags.hideMobile) mobileControls.style.display = 'none';
-        if (flags.hideMobile) mobileGameControls.style.display = 'none';
-        mobileControls.setAttribute('aria-hidden', String(!flags.showMobile));
-        mobileGameControls.setAttribute('aria-hidden', String(!flags.showMobile));
+        setMobileControlsDisplay(flags);
+        setMobileInGameControlsDisplay(flags);
+        setMobileControlsAria(flags);
     }
+
+/**
+ * Shows or hides the general on-screen mobile controls.
+ * @param {Object} flags - UI state flags from computeUIFlags().
+ */
+function setMobileControlsDisplay(flags) {
+    mobileControls.style.display = (flags.showMobile && !flags.hideMobile) ? 'flex' : 'none';
+    mobileGameControls.style.display = (flags.showMobile && !flags.hideMobile) ? 'flex' : 'none';
+}
+
+/**
+ * Shows or hides the mobile game controls (pause/mute overlay).
+ * @param {Object} flags - UI state flags from computeUIFlags().
+ */
+function setMobileInGameControlsDisplay(flags) {
+    if (flags.showMobile) {
+        inGameControls.classList.add('hide-screen');
+    } else {
+        inGameControls.classList.remove('show-screen');
+    }
+}
+
+/**
+ * Sets appropriate aria-hidden attributes for mobile UI controls.
+ * @param {Object} flags - UI state flags from computeUIFlags().
+ */
+function setMobileControlsAria(flags) {
+    mobileControls.setAttribute('aria-hidden', String(!flags.showMobile));
+    mobileGameControls.setAttribute('aria-hidden', String(!flags.showMobile));
+}
 
 /**
  * Shows or hides the rotation warning overlay.

--- a/scripts/mobile-ui.js
+++ b/scripts/mobile-ui.js
@@ -1,5 +1,6 @@
 (function () {
     const mobileControls = document.getElementById('mobileControls');
+    const mobileGameControls = document.getElementById('mobileGameControls');
     const rotateOverlay  = document.getElementById('rotateOverlay');
     const canvasScreen   = document.querySelector('.canvas-screen');
     const inGameControls = document.querySelector('.in-game-controls');
@@ -75,13 +76,16 @@
  */
     function updateMobileVisibility(flags) {
         mobileControls.style.display = flags.showMobile ? 'flex' : 'none';
+        mobileGameControls.style.display = flags.showMobile ? 'flex' : 'none';
         if (flags.showMobile) {
                 inGameControls.classList.add('hide-screen');
             } else {
                 inGameControls.classList.remove('show-screen');
             }        
         if (flags.hideMobile) mobileControls.style.display = 'none';
+        if (flags.hideMobile) mobileGameControls.style.display = 'none';
         mobileControls.setAttribute('aria-hidden', String(!flags.showMobile));
+        mobileGameControls.setAttribute('aria-hidden', String(!flags.showMobile));
     }
 
 /**

--- a/styles/style.css
+++ b/styles/style.css
@@ -631,4 +631,39 @@ h3 {
         justify-content: center;
         flex: unset;
     }
+
+    .mobile-thumb-controls {
+    position: fixed;
+    bottom: 2.5dvh; 
+    z-index: 950;
+    display: flex;
+    flex-direction: row;
+    gap: 0.1rem;
+    width: auto; 
+    align-items: center;
+    padding-bottom: env(safe-area-inset-bottom, 8px);
+    pointer-events: none; 
+    }
+
+    #mobileControlsLeft {
+        left: 1.5dvw;
+        align-items: flex-start;
+    }
+
+    #mobileControlsRight {
+        right: 1.5dvw;
+        align-items: flex-end;
+    }
+
+    .mobile-thumb-controls .control-btn {
+        width: 64px;
+        height: 25px;
+        min-width: 64px;
+        max-width: 90px;
+        font-size: 1rem;
+        border-radius: 18px;
+        pointer-events: auto;
+        box-sizing: border-box;
+        flex: unset;
+    }
 }

--- a/styles/style.css
+++ b/styles/style.css
@@ -608,7 +608,7 @@ h3 {
     }
 
     #mobileGameControls {
-        display: flex !important;
+        display: none;
         flex-direction: column;
         align-items: center;
         position: absolute;

--- a/styles/style.css
+++ b/styles/style.css
@@ -480,6 +480,10 @@ h3 {
 
 /* mobile devices --> (hover: none) and (pointer: coarse) */
 @media (hover: none) and (pointer: coarse) {
+    main {
+        overflow: hidden;
+    }
+    
     canvas {
         display: block;
         width: 100dvw;

--- a/styles/style.css
+++ b/styles/style.css
@@ -483,13 +483,14 @@ h3 {
     main {
         overflow: hidden;
     }
-    
+
     canvas {
         display: block;
         width: 100dvw;
         height: 100dvh;
         max-width: max-content;
         aspect-ratio: unset;
+        position: relative;
     }
 
     .canvas-screen {
@@ -604,5 +605,29 @@ h3 {
         font-size: 1rem;
         border-radius: 30px;
         margin-left: 2px;
+    }
+
+    #mobileGameControls {
+        display: flex !important;
+        flex-direction: column;
+        align-items: center;
+        position: absolute;
+        top: 0;
+        left: 50%;
+        transform: translateX(-50%);
+        z-index: 950;
+        background: none;
+        width: auto;
+        pointer-events: none;
+    }
+
+    #mobileGameControls .control-btn {
+        pointer-events: auto;
+        margin: 6px 0;
+        border-radius: 16px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        flex: unset;
     }
 }

--- a/styles/style.css
+++ b/styles/style.css
@@ -57,12 +57,13 @@ canvas {
 }
 
 .in-game-mute-btn {
-    border-radius: 90px;
     min-width: fit-content !important;
     height:fit-content;
     min-height: 50px !important;
     position: sticky;
     left: calc((100vw + 720px) / 2);
+    font-size: 1.5rem !important;
+    margin-bottom: 4px;
 }
 
 .show-screen {


### PR DESCRIPTION
close #62 


changed mobile control buttons into multiple sections:

bottom left:
- walk left/right

bottom right:
-  jump/throw

center top:
- pause/mute
